### PR TITLE
Dockerized Django App with entrypoint and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.8-slim
+
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y gcc libpq-dev
+
+WORKDIR /app
+
+COPY . /app
+COPY entrypoint.sh /app/entrypoint.sh
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+EXPOSE 8080
+
+CMD ["./entrypoint.sh"]

--- a/INSTRUCTION.md
+++ b/INSTRUCTION.md
@@ -1,0 +1,9 @@
+# Django ToDo App — Dockerized Deployment
+
+## 🔗 DockerHub
+(тут вставиш посилання на свій образ після push)
+
+## 🐳 Збірка Docker-образу:
+
+```bash
+sudo docker build -t todoapp .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+python manage.py migrate
+python manage.py runserver 0.0.0.0:8080


### PR DESCRIPTION
Створено Dockerfile з правильним запуском через entrypoint.sh
Перенесено міграції в entrypoint.sh (замість RUN під час build)
Додано INSTRUCTION.md з повною інструкцією
Перевірено — працює на http://localhost:8080/